### PR TITLE
Inline table references now work

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -489,13 +489,16 @@ neck_symptoms_imaging <- df |>
 neck_symptoms_imaging
 ```
 
-Neck symptoms were recorded in `r gtsummary::inline_text(neck_symptoms_imaging, variable="neck_symptoms")` of cases.
-Incidental imaging was performed in
-`r gtsummary::inline_text(neck_symptoms_imaging, variable="incidental_imaging")` cases of which
-Ultrasound (`r gtsummary::inline_text(neck_symptoms_imaging, variable="incidental_imaging_type", level="Ultrasound")`)
-and CT (`r gtsummary::inline_text(neck_symptoms_imaging, variable="incidental_imaging_type", level="CT")`)
+Neck symptoms and images are summarised in @tbl-neck-symptoms-imaging-gtsummary Neck symptoms were recorded in
+`r gtsummary::inline_text(neck_symptoms_imaging, variable="neck_symptoms")`
+of cases and incidental imaging was performed in
+`r gtsummary::inline_text(neck_symptoms_imaging, variable="incidental_imaging")`
+cases of which  Ultrasound
+(`r gtsummary::inline_text(neck_symptoms_imaging, variable="incidental_imaging_type", level="Ultrasound")`) and CT
+(`r gtsummary::inline_text(neck_symptoms_imaging, variable="incidental_imaging_type", level="CT")`)
 were the most common. Clinical assessment identified the most common nodule type to be single
 (`r gtsummary::inline_text(neck_symptoms_imaging, variable="clinical_assessment", level="Single thyroid node")`).
+
 
 
 <!-- ```{r} -->


### PR DESCRIPTION
Some minor changes as I noticed some of the text wasn't rendering when split over multiple lines in light of "hard-wrapping" at 120 characters. Specifically if an in-line code chunk is split over two lines it won't always render correctly.

I've therefore started having these on their own lines.

In Markdown consecutive lines without blanks between them are concatenated into paragraphs so this isn't an issue and it will also make it easier to "debug" and work out where things aren't quite right.

Should be ok to merge if you've not changed anything.